### PR TITLE
Selector API 리뷰 PR입니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-
+.git

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Selector API Test Page</title>
+  </head>
+  <body>
+    <h1>
+      아래에 보이시는 Selector API를 통해 문서내에 있는 요소들을 콘솔창으로 확인하시면 됩니다.
+    </h1>
+    <p>
+      1. selector에 해당하는 요소들을 찾아 해당 하는 제일 첫번째 요소만 배열로 반환해주는 함수, Domutil.querySelector("selector");
+    </p>
+    <p>
+      2. selector에 해당하는 요소들을 찾아 해당 하는 모든 요소를 배열로 반환해주는 함수, Domutil.querySelectorAll("selector");
+    </p>
+    <div class="wrap">
+      div.Wrap
+      <div class="area">
+        div.area
+        <p id="title">
+          p#title
+        </p>
+        <ul class="list">
+          <li>li</li>
+          <li>li</li>
+        </ul>
+        <ul class="list">
+          <li>li</li>
+          <li>
+            li
+            <p>p</p>
+          </li>
+        </ul>
+      </div>
+
+      <div class="area">
+        div.area
+        <div class="box">
+          div.box
+          <span id="date">#date</span>
+          <ol class="list">
+            <li id="first">li</li>
+            <li>li</li>
+            <li>li</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+
+    <script type="text/javascript" src="../src/index.js"></script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,13 +22,13 @@
           p#title
         </p>
         <ul class="list">
-          <li>li</li>
-          <li>li</li>
+          <li>li01</li>
+          <li>li02</li>
         </ul>
         <ul class="list">
-          <li>li</li>
+          <li>li03</li>
           <li>
-            li
+            li04
             <p>p</p>
           </li>
         </ul>
@@ -36,13 +36,13 @@
 
       <div class="area">
         div.area
-        <div class="box">
+        <div class="box" id="boxSection">
           div.box
           <span id="date">#date</span>
           <ol class="list">
-            <li id="first">li</li>
-            <li>li</li>
-            <li>li</li>
+            <li id="first">li05</li>
+            <li>li06</li>
+            <li>li07</li>
           </ol>
         </div>
       </div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      './src/index.js',
       './test/spec.js'
     ],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "karma test"
+    "test": "karma start"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "karma start"
+    "test": "karma start",
+    "serve": "ws"
   },
   "author": "",
   "license": "ISC",
@@ -16,6 +17,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.0",
     "karma-webpack": "^2.0.4",
+    "local-web-server": "^2.2.4",
     "webpack": "^3.5.6"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,122 @@
+
+
+// getElementsByClassName*() IE 8 이하 버전 호환
+var getElementsByClassNamePolyfil = function(rootEle, selector) {
+    var allElements;
+    var result;
+    var rClasName;
+    var i;
+    var allElementsLength;
+
+    if (document.getElementsByClassName) {
+        return rootEle.getElementsByClassName(selector);
+    }
+
+    allElements = rootEle.getElementsByTagName('*');
+    rClasName = new RegExp(selector);
+
+    i = 0;
+    allElementsLength = allElements.length;
+    for (i; i < allElementsLength; i += 1) {
+        if (rClasName.test(allElements[i].className)) {
+            result.push(allElements[i]);
+        }
+    }
+
+    return result;
+};
+
+var Domutil = (function() {
+    /*
+     * 1. selector의 앞에 문자열에 따라 id, class, tagName을 구별하여 해당하는 엘리멘트들의 배열을 반환하는 함수
+     * 2. rootEle, selector 두 개의 인자를 받는다. rootEle는 이전에 받은 결과값으로서 해당 값으로 다시 다음번째의 selector 값을 이용하여 값을 찾을때 사용한다.
+     */
+    var _findElementsOfMatchingSelector = function(rootEle, selectors) {
+        var result;
+        var rClasName = /^\./g;
+        var rIdName = /^#/g;
+
+        if (rClasName.test(selectors)) {
+            selectors = selectors.replace(rClasName, '');
+            result = getElementsByClassNamePolyfil(rootEle, selectors);
+            result = Array.prototype.slice.call(result);
+        } else if (rIdName.test(selectors)) {
+            selectors = selectors.replace(rIdName, '');
+            result = rootEle.getElementById(selectors);
+            result = [result];
+        } else {
+            result = rootEle.getElementsByTagName(selectors);
+            result = Array.prototype.slice.call(result);
+        }
+
+        return result;
+    };
+
+    // selector를 만족 시키는 요소들을 담은 배열을 생성하여 반환
+    var _makeArrayMatchingToSelctor = function(selectors) {
+        var founded; // founded, from 중에서 arrSeletor의 원소에 해당하는 결과를 저장하는 값
+        var from; // from, 찾아야 하는 대상이 되는 엘리멘트
+        var arrSeletor; // arrSeletor, 무엇을 찾아야 하는지 알려주는 값
+        var i;
+        var j;
+        var arrSeletorLength;
+        var fromLength;
+
+        if (!selectors) {
+            return [];
+        }
+
+        founded = [];
+        from = [document];
+        arrSeletor = selectors.split(' ');
+
+        i = 0;
+        arrSeletorLength = arrSeletor.length;
+        for (i; i < arrSeletorLength; i += 1) {
+            j = 0;
+            fromLength = from.length;
+            for (j; j < fromLength; j += 1) {
+                founded = founded.concat(_findElementsOfMatchingSelector(from[j], arrSeletor[i]));
+            }
+            from = founded;
+            founded = [];
+        }
+
+        return from;
+    };
+
+    var querySelector = function(selectors) {
+        var from = [];
+        var result = [];
+
+        from = _makeArrayMatchingToSelctor(selectors);
+
+        if (from.length < 1) {
+            result = [];
+        } else {
+            result.push(from[0]);
+        }
+
+        return result;
+    };
+
+    var querySelectorAll = function(selectors) {
+        var from = [];
+        var result = [];
+
+        from = _makeArrayMatchingToSelctor(selectors);
+
+        if (from.length < 1) {
+            result = [];
+        } else {
+            result = from;
+        }
+
+        return result;
+    };
+
+    return {
+        querySelector: querySelector,
+        querySelectorAll: querySelectorAll
+    };
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,11 @@ var Domutil = (function() {
         } else if (rIdName.test(selectors)) {
             selectors = selectors.replace(rIdName, '');
             result = document.getElementById(selectors);
-            result = [result];
+            if (result === null) {
+                result = [];
+            } else {
+                result = [result];
+            }
         } else {
             result = rootEle.getElementsByTagName(selectors);
             result = Array.prototype.slice.call(result);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 var Domutil = (function() {
-    var rMatchedClassName = /^\./g;
-    var rMatchedIdName = /^#/g;
 
     var _toArray = function(likeArray) {
         var result = [];
@@ -61,6 +59,8 @@ var Domutil = (function() {
      */
     var _findElementsOfMatchingSelector = function(rootEle, selectors) {
         var result = [];
+        var rMatchedClassName = /^\./g;
+        var rMatchedIdName = /^#/g;
 
         if (rMatchedClassName.test(selectors)) {
             selectors = selectors.replace(rMatchedClassName, '');
@@ -119,6 +119,7 @@ var Domutil = (function() {
             fromLength = from.length;
             for (; numFrom < fromLength; numFrom += 1) {
                 founded = founded.concat(_findElementsOfMatchingSelector(from[numFrom], arrSeletor[numArrSelector]));
+                //console.log(founded)
             }
 
             from = founded;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ var Domutil = (function() {
             result = Array.prototype.slice.call(result);
         } else if (rIdName.test(selectors)) {
             selectors = selectors.replace(rIdName, '');
-            result = rootEle.getElementById(selectors);
+            result = document.getElementById(selectors);
             result = [result];
         } else {
             result = rootEle.getElementsByTagName(selectors);

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,29 @@
-
-
-// getElementsByClassName*() IE 8 이하 버전 호환
-var getElementsByClassNamePolyfil = function(rootEle, selector) {
-    var allElements;
-    var result;
-    var rClasName;
-    var i;
-    var allElementsLength;
-
-    if (document.getElementsByClassName) {
-        return rootEle.getElementsByClassName(selector);
-    }
-
-    allElements = rootEle.getElementsByTagName('*');
-    rClasName = new RegExp(selector);
-
-    i = 0;
-    allElementsLength = allElements.length;
-    for (i; i < allElementsLength; i += 1) {
-        if (rClasName.test(allElements[i].className)) {
-            result.push(allElements[i]);
-        }
-    }
-
-    return result;
-};
-
 var Domutil = (function() {
+    // getElementsByClassName*() IE 8 이하 버전 호환
+    var _getElementsByClassNamePolyfill = function(rootEle, selector) {
+        var allElements;
+        var result;
+        var rClasName;
+        var i;
+        var allElementsLength;
+
+        if (document.getElementsByClassName) {
+            return rootEle.getElementsByClassName(selector);
+        }
+
+        allElements = rootEle.getElementsByTagName('*');
+        rClasName = new RegExp(selector);
+
+        i = 0;
+        allElementsLength = allElements.length;
+        for (i; i < allElementsLength; i += 1) {
+            if (rClasName.test(allElements[i].className)) {
+                result.push(allElements[i]);
+            }
+        }
+
+        return result;
+    };
     /*
      * 1. selector의 앞에 문자열에 따라 id, class, tagName을 구별하여 해당하는 엘리멘트들의 배열을 반환하는 함수
      * 2. rootEle, selector 두 개의 인자를 받는다. rootEle는 이전에 받은 결과값으로서 해당 값으로 다시 다음번째의 selector 값을 이용하여 값을 찾을때 사용한다.
@@ -38,7 +35,7 @@ var Domutil = (function() {
 
         if (rClasName.test(selectors)) {
             selectors = selectors.replace(rClasName, '');
-            result = getElementsByClassNamePolyfil(rootEle, selectors);
+            result = _getElementsByClassNamePolyfill(rootEle, selectors);
             result = Array.prototype.slice.call(result);
         } else if (rIdName.test(selectors)) {
             selectors = selectors.replace(rIdName, '');

--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,26 @@ var Domutil = (function() {
         var result = [];
         var i = 0;
         var likeArrayLength = likeArray.length;
+
         for (; i < likeArrayLength; i += 1) {
             result.push(likeArray[i]);
         }
+
         return result;
-    }
+    };
 
     var _indexOf = function(arr, obj) {
         var i = 0;
-        var arrLength = arr.length
-        for (var i = 0; i < arrLength; i += 1) {
+        var arrLength = arr.length;
+
+        for (; i < arrLength; i += 1) {
             if (arr[i] === obj) {
                 return i;
             }
-            return -1;
         }
-    }
+
+        return -1;
+    };
 
     // getElementsByClassName*() IE 8 이하 버전 호환
     var _getElementsByClassNamePolyfill = function(rootEle, selector) {
@@ -96,8 +100,8 @@ var Domutil = (function() {
     var _makeArrayMatchingToSelctor = function(selectors) {
         var founded = []; // founded, from 중에서 arrSeletor의 원소에 해당하는 결과를 저장하는 값
         var from = [document]; // from, 찾아야 하는 대상이 되는 엘리멘트
-        var arrSeletor = selectors.split(/\s+/);
         var result = [];
+        var arrSeletor;
         var numArrSelector;
         var numFrom;
         var arrSeletorLength;
@@ -107,6 +111,7 @@ var Domutil = (function() {
             return [];
         }
 
+        arrSeletor = selectors.split(/\s+/);
         numArrSelector = 0;
         arrSeletorLength = arrSeletor.length;
         for (; numArrSelector < arrSeletorLength; numArrSelector += 1) {

--- a/src/index.js
+++ b/src/index.js
@@ -53,11 +53,44 @@ var Domutil = (function() {
         return result;
     };
 
+    // from에 있는 요소 중에 중복되어 있는 요소를 제거한 배열을 반환
+    var _removeSameElement = function(from) {
+        var temp = [];
+        var x;
+        var y;
+        var count;
+        var fromLength;
+        var tempLength;
+
+        x = 0;
+        fromLength = from.length;
+        for (x; x < fromLength; x += 1) {
+            if (x === 0) {
+                temp.push(from[0]);
+            } else {
+                count = 0;
+                y = 0;
+                tempLength = temp.length;
+                for (y; y < tempLength; y += 1) {
+                    if (temp[y] === from[x]) {
+                        count += 1;
+                    }
+                }
+                if (count === 0) {
+                    temp.push(from[x]);
+                }
+            }
+        }
+
+        return temp;
+    };
+
     // selector를 만족 시키는 요소들을 담은 배열을 생성하여 반환
     var _makeArrayMatchingToSelctor = function(selectors) {
         var founded; // founded, from 중에서 arrSeletor의 원소에 해당하는 결과를 저장하는 값
         var from; // from, 찾아야 하는 대상이 되는 엘리멘트
         var arrSeletor; // arrSeletor, 무엇을 찾아야 하는지 알려주는 값
+        var result = [];
         var i;
         var j;
         var arrSeletorLength;
@@ -79,11 +112,14 @@ var Domutil = (function() {
             for (j; j < fromLength; j += 1) {
                 founded = founded.concat(_findElementsOfMatchingSelector(from[j], arrSeletor[i]));
             }
+
             from = founded;
             founded = [];
         }
 
-        return from;
+        result = _removeSameElement(from);
+
+        return result;
     };
 
     var querySelector = function(selectors) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@ var Domutil = (function() {
     // getElementsByClassName*() IE 8 이하 버전 호환
     var _getElementsByClassNamePolyfill = function(rootEle, selector) {
         var allElements;
-        var result;
-        var rClasName;
+        var result = [];
+        var rClassName;
         var i;
         var allElementsLength;
 
@@ -12,12 +12,12 @@ var Domutil = (function() {
         }
 
         allElements = rootEle.getElementsByTagName('*');
-        rClasName = new RegExp(selector);
+        rClassName = new RegExp(selector);
 
         i = 0;
         allElementsLength = allElements.length;
         for (i; i < allElementsLength; i += 1) {
-            if (rClasName.test(allElements[i].className)) {
+            if (rClassName.test(allElements[i].className)) {
                 result.push(allElements[i]);
             }
         }
@@ -29,12 +29,12 @@ var Domutil = (function() {
      * 2. rootEle, selector 두 개의 인자를 받는다. rootEle는 이전에 받은 결과값으로서 해당 값으로 다시 다음번째의 selector 값을 이용하여 값을 찾을때 사용한다.
      */
     var _findElementsOfMatchingSelector = function(rootEle, selectors) {
-        var result;
-        var rClasName = /^\./g;
+        var result = [];
+        var rClassName = /^\./g;
         var rIdName = /^#/g;
 
-        if (rClasName.test(selectors)) {
-            selectors = selectors.replace(rClasName, '');
+        if (rClassName.test(selectors)) {
+            selectors = selectors.replace(rClassName, '');
             result = _getElementsByClassNamePolyfill(rootEle, selectors);
             result = Array.prototype.slice.call(result);
         } else if (rIdName.test(selectors)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,50 +1,49 @@
 var Domutil = (function() {
+    var rMatchedClassName = /^\./g;
+    var rMatchedIdName = /^#/g;
+
     // getElementsByClassName*() IE 8 이하 버전 호환
     var _getElementsByClassNamePolyfill = function(rootEle, selector) {
-        var allElements;
         var result = [];
-        var rClassName;
+        var allElements;
+        var testClassName;
         var i;
         var allElementsLength;
 
         if (document.getElementsByClassName) {
-            return rootEle.getElementsByClassName(selector);
+            return [].slice.call(rootEle.getElementsByClassName(selector));
         }
 
         allElements = rootEle.getElementsByTagName('*');
-        rClassName = new RegExp(selector);
+        testClassName = new RegExp(selector);
 
         i = 0;
         allElementsLength = allElements.length;
-        for (i; i < allElementsLength; i += 1) {
-            if (rClassName.test(allElements[i].className)) {
+        for (; i < allElementsLength; i += 1) {
+            if (testClassName.test(allElements[i].className)) {
                 result.push(allElements[i]);
             }
         }
 
-        return result;
+        return [].slice.call(result);
     };
-    /*
-     * 1. selector의 앞에 문자열에 따라 id, class, tagName을 구별하여 해당하는 엘리멘트들의 배열을 반환하는 함수
-     * 2. rootEle, selector 두 개의 인자를 받는다. rootEle는 이전에 받은 결과값으로서 해당 값으로 다시 다음번째의 selector 값을 이용하여 값을 찾을때 사용한다.
+
+    /**
+     * selector의 앞에 문자열에 따라 id, class, tagName을 구별하여 해당하는 엘리멘트들의 배열을 반환하는 함수
+     * @param {object} rootEle 는 이전에 받은 결과값으로서 해당 값으로 다시 다음번째의 selector 값을 이용하여 값을 찾을때 사용한다.
+     * @param {string} selectors 검색해야하는 selector 값
+     * @returns {array} result 는 해당 selector에 의해 검색되어진 결과값 배열
      */
     var _findElementsOfMatchingSelector = function(rootEle, selectors) {
         var result = [];
-        var rClassName = /^\./g;
-        var rIdName = /^#/g;
 
-        if (rClassName.test(selectors)) {
-            selectors = selectors.replace(rClassName, '');
+        if (rMatchedClassName.test(selectors)) {
+            selectors = selectors.replace(rMatchedClassName, '');
             result = _getElementsByClassNamePolyfill(rootEle, selectors);
-            result = Array.prototype.slice.call(result);
-        } else if (rIdName.test(selectors)) {
-            selectors = selectors.replace(rIdName, '');
+        } else if (rMatchedIdName.test(selectors)) {
+            selectors = selectors.replace(rMatchedIdName, '');
             result = document.getElementById(selectors);
-            if (result === null) {
-                result = [];
-            } else {
-                result = [result];
-            }
+            result = (result === null) ? [] : [result];
         } else {
             result = rootEle.getElementsByTagName(selectors);
             result = Array.prototype.slice.call(result);
@@ -56,29 +55,16 @@ var Domutil = (function() {
     // from에 있는 요소 중에 중복되어 있는 요소를 제거한 배열을 반환
     var _removeSameElement = function(from) {
         var temp = [];
-        var x;
-        var y;
-        var count;
-        var fromLength;
-        var tempLength;
+        var numFrom = 0;
+        var fromLength = from.length;
 
-        x = 0;
-        fromLength = from.length;
-        for (x; x < fromLength; x += 1) {
-            if (x === 0) {
+        for (; numFrom < fromLength; numFrom += 1) {
+            if (numFrom === 0) {
                 temp.push(from[0]);
+            } else if (temp.indexOf(from[numFrom]) > -1) {
+                break;
             } else {
-                count = 0;
-                y = 0;
-                tempLength = temp.length;
-                for (y; y < tempLength; y += 1) {
-                    if (temp[y] === from[x]) {
-                        count += 1;
-                    }
-                }
-                if (count === 0) {
-                    temp.push(from[x]);
-                }
+                temp.push(from[numFrom]);
             }
         }
 
@@ -87,12 +73,12 @@ var Domutil = (function() {
 
     // selector를 만족 시키는 요소들을 담은 배열을 생성하여 반환
     var _makeArrayMatchingToSelctor = function(selectors) {
-        var founded; // founded, from 중에서 arrSeletor의 원소에 해당하는 결과를 저장하는 값
-        var from; // from, 찾아야 하는 대상이 되는 엘리멘트
-        var arrSeletor; // arrSeletor, 무엇을 찾아야 하는지 알려주는 값
+        var founded = []; // founded, from 중에서 arrSeletor의 원소에 해당하는 결과를 저장하는 값
+        var from = [document]; // from, 찾아야 하는 대상이 되는 엘리멘트
+        var arrSeletor = selectors.split(/\s+/);
         var result = [];
-        var i;
-        var j;
+        var numArrSelector;
+        var numFrom;
         var arrSeletorLength;
         var fromLength;
 
@@ -100,17 +86,13 @@ var Domutil = (function() {
             return [];
         }
 
-        founded = [];
-        from = [document];
-        arrSeletor = selectors.split(' ');
-
-        i = 0;
+        numArrSelector = 0;
         arrSeletorLength = arrSeletor.length;
-        for (i; i < arrSeletorLength; i += 1) {
-            j = 0;
+        for (; numArrSelector < arrSeletorLength; numArrSelector += 1) {
+            numFrom = 0;
             fromLength = from.length;
-            for (j; j < fromLength; j += 1) {
-                founded = founded.concat(_findElementsOfMatchingSelector(from[j], arrSeletor[i]));
+            for (; numFrom < fromLength; numFrom += 1) {
+                founded = founded.concat(_findElementsOfMatchingSelector(from[numFrom], arrSeletor[numArrSelector]));
             }
 
             from = founded;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,27 @@ var Domutil = (function() {
     var rMatchedClassName = /^\./g;
     var rMatchedIdName = /^#/g;
 
+    var _toArray = function(likeArray) {
+        var result = [];
+        var i = 0;
+        var likeArrayLength = likeArray.length;
+        for (; i < likeArrayLength; i += 1) {
+            result.push(likeArray[i]);
+        }
+        return result;
+    }
+
+    var _indexOf = function(arr, obj) {
+        var i = 0;
+        var arrLength = arr.length
+        for (var i = 0; i < arrLength; i += 1) {
+            if (arr[i] === obj) {
+                return i;
+            }
+            return -1;
+        }
+    }
+
     // getElementsByClassName*() IE 8 이하 버전 호환
     var _getElementsByClassNamePolyfill = function(rootEle, selector) {
         var result = [];
@@ -11,7 +32,7 @@ var Domutil = (function() {
         var allElementsLength;
 
         if (document.getElementsByClassName) {
-            return [].slice.call(rootEle.getElementsByClassName(selector));
+            return _toArray(rootEle.getElementsByClassName(selector));
         }
 
         allElements = rootEle.getElementsByTagName('*');
@@ -25,7 +46,7 @@ var Domutil = (function() {
             }
         }
 
-        return [].slice.call(result);
+        return result;
     };
 
     /**
@@ -46,7 +67,7 @@ var Domutil = (function() {
             result = (result === null) ? [] : [result];
         } else {
             result = rootEle.getElementsByTagName(selectors);
-            result = Array.prototype.slice.call(result);
+            result = _toArray(result);
         }
 
         return result;
@@ -61,7 +82,7 @@ var Domutil = (function() {
         for (; numFrom < fromLength; numFrom += 1) {
             if (numFrom === 0) {
                 temp.push(from[0]);
-            } else if (temp.indexOf(from[numFrom]) > -1) {
+            } else if (_indexOf(temp, from[numFrom]) > -1) {
                 break;
             } else {
                 temp.push(from[numFrom]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,7 +1,7 @@
 describe('Domutil.querySelector function should be return array ', function() {
     // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
     it('should be return array', function() {
-        expect(Array.isArray(Domutil.querySelector())).toBe(true);
+        expect(Domutil.querySelector()).toEqual([]);
     });
 
     // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환
@@ -44,7 +44,7 @@ describe('Domutil.querySelector function should be return array ', function() {
 describe('Domutil.querySelectorAll function should be return array ', function() {
     // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
     it('should be return array', function() {
-        expect(Array.isArray(Domutil.querySelectorAll())).toBe(true);
+        expect(Domutil.querySelectorAll()).toEqual([]);
     });
 
     // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환
@@ -84,7 +84,7 @@ describe('Domutil.querySelectorAll function should be return array ', function()
     });
 });
 
-describe('getElementsByClassName Pollyfil', function() {
+xdescribe('getElementsByClassName Pollyfil', function() {
     it('Should be return main class elements', function() {
         document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
         expect(getElementsByClassNamePolyfil(document, 'main').length).toBe(2);

--- a/test/spec.js
+++ b/test/spec.js
@@ -50,7 +50,7 @@ describe('Domutil.querySelector function should be return array ', function() {
 describe('Domutil.querySelectorAll function should be return array ', function() {
     // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
     it('should be return array', function() {
-        expect(Domutil.querySelectorAll()).toEqual([]);
+        expect(Domutil.querySelectorAll()).toEqual(jasmine.any(array));
     });
 
     // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환

--- a/test/spec.js
+++ b/test/spec.js
@@ -28,6 +28,12 @@ describe('Domutil.querySelector function should be return array ', function() {
         expect(Domutil.querySelector('.main div').length).toBe(1);
     });
 
+    // 셀렉터가 두 개인 경우, .main #cont의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (.className #idName), should be return array .className tagName element', function() {
+        document.body.innerHTML = '<div class="main">no main</div><div class="main"><div id="cont">.main div</div></div>';
+        expect(Domutil.querySelector('.main #cont').length).toBe(1);
+    });
+
     // 셀렉터가 세 개인 경우, .#cont div span의 해당하는 엘레멘트 배열을 반환
     it('if selector is (#id tagName tagName), should be return array #id tagName tagName', function() {
         document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div><div class="main"><div><span>.main</span> div</div></div>';
@@ -81,6 +87,12 @@ describe('Domutil.querySelectorAll function should be return array ', function()
     it('if selector is (.className tagName tagName), should be return array .className tagName tagName element', function() {
         document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
         expect(Domutil.querySelectorAll('.main div span').length).toBe(2);
+    });
+
+    // 셀렉터가 두 개인 경우, div li의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (tagName tagName), should be return array tagNam tagName element', function() {
+        document.body.innerHTML = '<div class="wrap">div.Wrap<div class="area">div.area<p id="title">p#title</p><ul class="list"><li>li01</li><li>li02</li></ul><ul class="list"><li>li03</li><li>li04<p>p</p></li></ul></div><div class="area">div.area<div class="box" id="boxSection">div.box<span id="date">#date</span><ol class="list"><li id="first">li05</li><li>li06</li><li>li07</li></ol></div></div></div>'
+        expect(Domutil.querySelectorAll('div li').length).toBe(7);
     });
 });
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,7 +1,7 @@
 describe('Domutil.querySelector function should be return array ', function() {
     // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
     it('should be return array', function() {
-        expect(Domutil.querySelector()).toEqual([]);
+        expect(Domutil.querySelector()).toEqual(jasmine.any(Array));
     });
 
     // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환
@@ -50,7 +50,7 @@ describe('Domutil.querySelector function should be return array ', function() {
 describe('Domutil.querySelectorAll function should be return array ', function() {
     // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
     it('should be return array', function() {
-        expect(Domutil.querySelectorAll()).toEqual(jasmine.any(array));
+        expect(Domutil.querySelectorAll()).toEqual(jasmine.any(Array));
     });
 
     // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,0 +1,92 @@
+describe('Domutil.querySelector function should be return array ', function() {
+    // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
+    it('should be return array', function() {
+        expect(Array.isArray(Domutil.querySelector())).toBe(true);
+    });
+
+    // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is class, should be return array class element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div>no main</div>';
+        expect(Domutil.querySelector('.main').length).toBe(1);
+    });
+
+    // 셀렉터가 id인 경우, 해당 id를 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is id, should be return array id element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div id="cont">no main</div>';
+        expect(Domutil.querySelector('#cont').length).toBe(1);
+    });
+
+    // 셀렉터가 tagName인 경우, 해당 tagName을 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is tagName, should be return array tagName element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div id="cont">no main</div>';
+        expect(Domutil.querySelector('div').length).toBe(1);
+    });
+
+    // 셀렉터가 두 개인 경우, .main div의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (.className tagName), should be return array .className tagName element', function() {
+        document.body.innerHTML = '<div id="cont" class="main">no main</div><div class="main"><div>.main div</div></div>';
+        expect(Domutil.querySelector('.main div').length).toBe(1);
+    });
+
+    // 셀렉터가 세 개인 경우, .#cont div span의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (#id tagName tagName), should be return array #id tagName tagName', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div><div class="main"><div><span>.main</span> div</div></div>';
+        expect(Domutil.querySelector('#cont div span').length).toBe(1);
+    });
+
+    // 셀렉터가 세 개인 경우, .main div span의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (.className tagName tagName), should be return array .className tagName tagName element', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
+        expect(Domutil.querySelector('.main div span').length).toBe(1);
+    });
+});
+
+describe('Domutil.querySelectorAll function should be return array ', function() {
+    // Selector API 요구조건, 배열을 반환해야 한다 테스트 케이스 작성
+    it('should be return array', function() {
+        expect(Array.isArray(Domutil.querySelectorAll())).toBe(true);
+    });
+
+    // 셀렉터가 class인 경우, 해당 class를 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is class, should be return array class element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div class="main">no main</div>';
+        expect(Domutil.querySelectorAll('.main').length).toBe(2);
+    });
+
+    // 셀렉터가 id인 경우, 해당 id를 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is id, should be return array id element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div id="cont">no main</div>';
+        expect(Domutil.querySelectorAll('#cont').length).toBe(1);
+    });
+
+    // 셀렉터가 tagName인 경우, 해당 tagName을 가지고 있는 엘리멘트 배열을 반환
+    it('if selector is tagName, should be return array tagName element', function() {
+        document.body.innerHTML = '<div class="main">main</div><div id="cont"><div>no main</div></div>';
+        expect(Domutil.querySelectorAll('div').length).toBe(3);
+    });
+
+    // 셀렉터가 두 개인 경우, .main div의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (.className tagName), should be return array .className tagName element', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div>no main</div></div><div class="main"><div>.main div</div></div>';
+        expect(Domutil.querySelectorAll('.main div').length).toBe(2);
+    });
+
+    // 셀렉터가 세 개인 경우, .#cont div span의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (#id tagName tagName), should be return array #id tagName tagName', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span><span>span</span></div></div><div class="main"><div><span>.main</span> div</div></div>';
+        expect(Domutil.querySelectorAll('#cont div span').length).toBe(2);
+    });
+
+    // 셀렉터가 세 개인 경우, .main div span의 해당하는 엘레멘트 배열을 반환
+    it('if selector is (.className tagName tagName), should be return array .className tagName tagName element', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
+        expect(Domutil.querySelectorAll('.main div span').length).toBe(2);
+    });
+});
+
+describe('getElementsByClassName Pollyfil', function() {
+    it('Should be return main class elements', function() {
+        document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
+        expect(getElementsByClassNamePolyfil(document, 'main').length).toBe(2);
+    });
+});

--- a/test/spec.js
+++ b/test/spec.js
@@ -84,9 +84,34 @@ describe('Domutil.querySelectorAll function should be return array ', function()
     });
 });
 
-xdescribe('getElementsByClassName Pollyfil', function() {
+describe('getElementsByClassName Pollyfil', function() {
+    var _getElementsByClassNamePolyfill = function(rootEle, selector) {
+        var allElements;
+        var result = [];
+        var rClassName;
+        var i;
+        var allElementsLength;
+
+        if (document.getElementsByClassName) {
+            return rootEle.getElementsByClassName(selector);
+        }
+
+        allElements = rootEle.getElementsByTagName('*');
+        rClassName = new RegExp(selector);
+
+        i = 0;
+        allElementsLength = allElements.length;
+        for (i; i < allElementsLength; i += 1) {
+            if (rClassName.test(allElements[i].className)) {
+                result.push(allElements[i]);
+            }
+        }
+
+        return result;
+    };
+
     it('Should be return main class elements', function() {
         document.body.innerHTML = '<div id="cont" class="main"><div><span>no main</span></div></div> <div class="main"><div><span>.main</span></div></div>';
-        expect(getElementsByClassNamePolyfil(document, 'main').length).toBe(2);
+        expect(_getElementsByClassNamePolyfill(document, 'main').length).toBe(2);
     });
 });


### PR DESCRIPTION
**데모페이지**
[데모페이지 이동](http://10.78.65.35:8000/examples/)

**소개**
- Selector API의 구현인 querySelector와 querySelectorAll를 직접 구현한다.
- 실제 구현 전에 요구사항에 맞는 TC를 우선 작성 후 공유한다.

**요구사항**
- getElementById, getElementByTagName을 이용해 구현한다. (특정 IE에서 이슈가 있는 getElementByClassName도 직접 구현한다.)
- .class, #id, tag 3개의 셀렉터만 이용할 수 있다.
- 셀렉터의 조합으로 엘리먼트를 찾을 수 있다 배열로 엘리먼트를 직접 반환함.

```
domutil.querySelectorAll('.class');
domutil.querySelector('#id');

//myClass라는 클래스를 가진 엘리먼트의 자식요소중 div를 모두 리턴
domutil.querySelectorAll('.myClass div');

```